### PR TITLE
Conform to Go getter format

### DIFF
--- a/otp/hotp.go
+++ b/otp/hotp.go
@@ -8,11 +8,11 @@ type HOTP struct {
 	digits int
 }
 
-func (hotp HOTP) GetCode() any {
+func (hotp HOTP) Code() any {
 	return hotp.code
 }
 
-func (hotp HOTP) GetDigits() int {
+func (hotp HOTP) Digits() int {
 	return hotp.digits
 }
 

--- a/otp/motp.go
+++ b/otp/motp.go
@@ -11,11 +11,11 @@ type MOTP struct {
 	digits int
 }
 
-func (motp MOTP) GetCode() any {
+func (motp MOTP) Code() any {
 	return motp.code
 }
 
-func (motp MOTP) GetDigits() int {
+func (motp MOTP) Digits() int {
 	return motp.digits
 }
 

--- a/otp/otp.go
+++ b/otp/otp.go
@@ -12,8 +12,8 @@ import (
 )
 
 type OTP interface {
-	GetCode() any
-	GetDigits() int
+	Code() any
+	Digits() int
 	String() string
 }
 

--- a/otp/steam_otp.go
+++ b/otp/steam_otp.go
@@ -12,11 +12,11 @@ type SteamOTP struct {
 	digits int
 }
 
-func (sotp SteamOTP) GetCode() any {
+func (sotp SteamOTP) Code() any {
 	return sotp.code
 }
 
-func (sotp SteamOTP) GetDigits() int {
+func (sotp SteamOTP) Digits() int {
 	return sotp.digits
 }
 

--- a/otp/totp.go
+++ b/otp/totp.go
@@ -11,11 +11,11 @@ type TOTP struct {
 	digits int
 }
 
-func (totp TOTP) GetCode() any {
+func (totp TOTP) Code() any {
 	return totp.code
 }
 
-func (totp TOTP) GetDigits() int {
+func (totp TOTP) Digits() int {
 	return totp.digits
 }
 


### PR DESCRIPTION
Including 'Get' in the exported getter method's name isn't necessary in Go.

See: https://go.dev/doc/effective_go#Getters